### PR TITLE
Add start of ordered lists

### DIFF
--- a/MarkedNet/Lexer.cs
+++ b/MarkedNet/Lexer.cs
@@ -217,11 +217,15 @@ namespace MarkedNet
                 {
                     src = src.Substring(cap[0].Length);
                     var bull = cap[2];
+                    int start = 1;
+                    if (!int.TryParse(bull.TrimEnd('.').Trim(), out start))
+                        start = 1;
 
                     tokens.Add(new Token
                     {
                         Type = "list_start",
-                        Ordered = bull.Length > 1
+                        Ordered = bull.Length > 1,
+                        Start = start
                     });
 
                     // Get each top-level item.

--- a/MarkedNet/Marked.cs
+++ b/MarkedNet/Marked.cs
@@ -29,9 +29,10 @@ namespace MarkedNet
                 return src;
             }
 
+            src = Options.Renderer.Preprocess(src);
             var tokens = Lexer.Lex(src, Options);
             var result = Parser.Parse(tokens, Options);
-            return result;
+            return Options.Renderer.Postprocess(result);
         }
     }
 }

--- a/MarkedNet/Options.cs
+++ b/MarkedNet/Options.cs
@@ -62,7 +62,7 @@ namespace MarkedNet
             XHtml = false;
             Sanitize = false;
             Pedantic = false;
-            Mangle = true;
+            Mangle = false;
             Smartypants = false;
             Breaks = false;
             Gfm = true;

--- a/MarkedNet/Options.cs
+++ b/MarkedNet/Options.cs
@@ -62,7 +62,7 @@ namespace MarkedNet
             XHtml = false;
             Sanitize = false;
             Pedantic = false;
-            Mangle = false;
+            Mangle = true;
             Smartypants = false;
             Breaks = false;
             Gfm = true;

--- a/MarkedNet/Parser.cs
+++ b/MarkedNet/Parser.cs
@@ -152,13 +152,13 @@ namespace MarkedNet
                     {
                         var body = String.Empty;
                         var ordered = this.token.Ordered;
-
+                        var start = this.token.Start;
                         while (this.Next().Type != "list_end")
                         {
                             body += this.Tok();
                         }
 
-                        return _options.Renderer.List(body, ordered);
+                        return _options.Renderer.List(body, ordered, start);
                     }
                 case "list_item_start":
                     {

--- a/MarkedNet/Renderer.cs
+++ b/MarkedNet/Renderer.cs
@@ -87,9 +87,11 @@ namespace MarkedNet
             return Options.XHtml ? "<hr/>\n" : "<hr>\n";
         }
 
-        public virtual string List(string body, bool ordered)
+        public virtual string List(string body, bool ordered, int start)
         {
             var type = ordered ? "ol" : "ul";
+            if (ordered && start != 1)
+                return $"<ol start=\"{start}\">\n{body}\n</ol>\n";
             return "<" + type + ">\n" + body + "</" + type + ">\n";
         }
 
@@ -205,6 +207,26 @@ namespace MarkedNet
         public virtual string Text(string text)
         {
           return text;
+        }
+
+        /// <summary>
+        /// Preprocess entire input before parsing
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public virtual string Preprocess(string text)
+        {
+            return text;
+        }
+
+        /// <summary>
+        /// ppostprocess entire output before returning
+        /// </summary>
+        /// <param name="text"></param>
+        /// <returns></returns>
+        public virtual string Postprocess(string text)
+        {
+            return text;
         }
     
         #endregion

--- a/MarkedNet/Token.cs
+++ b/MarkedNet/Token.cs
@@ -17,6 +17,8 @@ namespace MarkedNet
         public string Lang { get; set; }
         public bool Ordered { get; set; }
 
+        public int Start { get; set; }
+
         public bool Pre { get; set; }
 
         public IList<string> Header { get; set; }


### PR DESCRIPTION
For ordered lists I added ability to set the start of the ordered list. For example:

```
0. item a 
1. item b
2. item c 
```

becomes:

```
<ol start ='0'>
   <li>item a</li>
   <li>item b</li>
   <li>item c</li>
</ol>
```

In addition, I added Preprocess and Postprocess virtual methods which give derived classes the ability to pre and post process entire input/output.
